### PR TITLE
Pollを従来のlinepyみたいに使えるようにする & 型ヒント

### DIFF
--- a/CHRLINE/poll.py
+++ b/CHRLINE/poll.py
@@ -1,67 +1,95 @@
-# -*- coding: utf-8 -*-
 import threading
 import traceback
+from typing import Callable, Generator, Optional
+
+from CHRLINE.services.thrift.ttypes import OpType
 
 
 class Poll(object):
+    op_interrupt: dict[int, Callable[[dict, object], None]]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.subscriptionId = 0
         self.eventSyncToken = None
+        self.op_interrupt = {}
 
-    def __fetchOps(self, count=100):
+    def __fetchOps(self, count: int = 100) -> Generator[dict, None, None]:
         fetchOps = self.fetchOps
         if self.DEVICE_TYPE in self.SYNC_SUPPORT:
             fetchOps = self.sync
         ops = fetchOps(self.revision, count)
-        if 'error' in ops:
-            raise Exception(ops['error'])
+        if "error" in ops:
+            raise Exception(ops["error"])
         for op in ops:
-            opType = self.checkAndGetValue(op, 'type', 3)
-            if opType != -1:
-                self.setRevision(self.checkAndGetValue(op, 'revision', 1))
+            op_type = self.checkAndGetValue(op, "type", 3)
+            if op_type != -1:
+                self.setRevision(self.checkAndGetValue(op, "revision", 1))
             yield op
 
-    def __fetchMyEvents(self, count: int = 100, initLastSyncToken: bool = False):
-        resp = self.fetchMyEvents(self.subscriptionId, self.eventSyncToken, count)
-        events = self.checkAndGetValue(resp, 'events', 2)
+    def __fetchMyEvents(
+        self, count: int = 100, initLastSyncToken: bool = False
+    ) -> Generator[dict, None, None]:
+        resp = self.fetchMyEvents(
+            self.subscriptionId, self.eventSyncToken, count
+        )
+        events = self.checkAndGetValue(resp, "events", 2)
         for event in events:
-            syncToken = self.checkAndGetValue(event, 'syncToken', 5)
+            syncToken = self.checkAndGetValue(event, "syncToken", 5)
             self.setEventSyncToken(syncToken)
             yield event
         if initLastSyncToken:
-            syncToken = self.checkAndGetValue(resp, 'syncToken', 3)
+            syncToken = self.checkAndGetValue(resp, "syncToken", 3)
             self.setEventSyncToken(syncToken)
 
-    def __execute(self, op, func):
+    def __execute(
+        self, op: dict, func: Callable[[dict, object], None]
+    ) -> None:
         try:
             func(op, self)
-        except Exception as e:
+        except Exception:
             self.log(traceback.format_exc())
 
-    def setRevision(self, revision):
+    def setRevision(self, revision: Optional[int]) -> None:
         if revision is None:
-            self.log(f'revision is None!!')
+            self.log("revision is None!!")
             revision = 0
         self.revision = max(revision, self.revision)
 
-    def setEventSyncToken(self, syncToken):
+    def setEventSyncToken(self, syncToken: Optional[int]) -> None:
         if syncToken is None:
-            self.log(f'syncToken is None!!')
+            self.log("syncToken is None!!")
             syncToken = 0
         if self.eventSyncToken is None:
             self.eventSyncToken = syncToken
         else:
             self.eventSyncToken = max(int(syncToken), int(self.eventSyncToken))
 
-    def trace(self, func, isThreading=True):
+    def add_op_interrupt(
+        self, op_type: int, func: Callable[[dict, object], None]
+    ) -> None:
+        self.op_interrupt[op_type] = func
+
+    def add_op_interrupt_with_dict(
+        self, d: dict[int, Callable[[dict, object], None]]
+    ) -> None:
+        self.op_interrupt.update(d)
+
+    def trace(self, isThreading: bool = True) -> None:
         while self.is_login:
             for op in self.__fetchOps():
-                opType = self.checkAndGetValue(op, 'type', 'val_3', 3)
-                if opType != 0 and opType != -1:
-                    if isThreading:
-                        _td = threading.Thread(target=self.__execute, args=(op, func))
-                        _td.daemon = True
-                        _td.start()
-                    else:
-                        self.__execute(op, func)
+                op_type: int = self.checkAndGetValue(op, "type", "val_3", 3)
+                if op_type in [-1, OpType.END_OF_OPERATION]:
+                    continue
+
+                func = self.op_interrupt.get(op_type)
+                if func is None:
+                    continue
+
+                if isThreading:
+                    _td = threading.Thread(
+                        target=self.__execute, args=(op, func)
+                    )
+                    _td.daemon = True
+                    _td.start()
+                else:
+                    self.__execute(op, func)


### PR DESCRIPTION
```python
from datetime import datetime
from typing import Any

from CHRLINE import CHRLINE
from CHRLINE.services.thrift.ttypes import ContentType, MIDType, OpType

cl = CHRLINE()

try:
    cl.getE2EESelfKeyData(cl.mid)
except Exception:
    cl.registerE2EESelfKey()


def test(op: dict[int, Any], bot: CHRLINE) -> None:
    print(op)

    msg: dict[int, Any] = op.get(20, {})

    # not text
    if msg[15] != ContentType.NONE:
        return
    text: str = msg.get(10, "")

    # e2e
    e2e: dict[str, str] = msg.get(18, {})
    if "e2eeVersion" in e2e:
        text = bot.decryptE2EETextMessage(msg)

    unixtime: int = msg[5]
    message_id: int = msg[4]
    if msg[3] == MIDType.GROUP:
        mid: str = msg[1]
        gid: str = msg[2]
        if text == "/me":
            cl.sendContact(gid, mid)
        elif text == "/mid":
            cl.replyMessage(msg, mid)
        elif text == "おっぱい":
            cl.replyMessage(msg, "ぶるんぶるん")
        elif text == "/messageId":
            cl.replyMessage(msg, str(message_id))
        elif text == "/time":
            cl.replyMessage(msg, str(unixtime / 1000))
            cl.replyMessage(msg, str(datetime.fromtimestamp(unixtime / 1000)))


cl.add_op_interrupt(OpType.RECEIVE_MESSAGE, test)
try:
    cl.trace()
except KeyboardInterrupt:
    exit()
except Exception:
    raise

```